### PR TITLE
fix(opentelemetry): fixed start span from given traceID/spanID

### DIFF
--- a/integrations/tracer/opentelemetry/opentelemetry.go
+++ b/integrations/tracer/opentelemetry/opentelemetry.go
@@ -6,7 +6,6 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
-
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -34,7 +33,7 @@ func NewTracer(serviceName string, opts ...Option) *Tracer {
 
 // Version returns the current tracer's version
 func (t *Tracer) Version() string {
-	return "v0.1.0"
+	return "v0.1.1"
 }
 
 type Option func(*Tracer)

--- a/integrations/tracer/opentelemetry/opentelemetry_test.go
+++ b/integrations/tracer/opentelemetry/opentelemetry_test.go
@@ -1,8 +1,9 @@
 package opentelemetry
 
 import (
-	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"testing"
+
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 )
 
 func TestOpentelemetry_NewTracer(t *testing.T) {

--- a/integrations/tracer/opentelemetry/span.go
+++ b/integrations/tracer/opentelemetry/span.go
@@ -3,12 +3,12 @@ package opentelemetry
 import (
 	"context"
 	"fmt"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"time"
 
 	tengcoruxTracer "github.com/rmscoal/tengcorux/tracer"
 	tengcoruxAttribute "github.com/rmscoal/tengcorux/tracer/attribute"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/integrations/tracer/opentelemetry/span_test.go
+++ b/integrations/tracer/opentelemetry/span_test.go
@@ -3,11 +3,12 @@ package opentelemetry
 import (
 	"context"
 	"errors"
+	"testing"
+
 	tengcoruxTracer "github.com/rmscoal/tengcorux/tracer"
 	"github.com/rmscoal/tengcorux/tracer/attribute"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/trace"
-	"testing"
 )
 
 func TestSpan(t *testing.T) {

--- a/integrations/tracer/opentelemetry/tracer_test.go
+++ b/integrations/tracer/opentelemetry/tracer_test.go
@@ -2,19 +2,81 @@ package opentelemetry
 
 import (
 	"context"
-	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	tengcoruxTracer "github.com/rmscoal/tengcorux/tracer"
 	"testing"
 	"time"
+
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestTracer_StartSpan(t *testing.T) {
-	tracer := NewTracer("testing")
-	ctx, span := tracer.StartSpan(context.TODO(), "test")
-	if ctx == nil {
-		t.Fatal("expected non-nil context")
-	} else if span == nil {
-		t.Fatal("expected non-nil span")
-	}
+	tt := tracetest.NewNoopExporter()
+	tracer := NewTracer("testing", WithExporter(tt))
+
+	t.Run("Normal(Noop)", func(t *testing.T) {
+		ctx, span := tracer.StartSpan(context.TODO(), "test")
+		if ctx == nil {
+			t.Fatal("expected non-nil context")
+		} else if span == nil {
+			t.Fatal("expected non-nil span")
+		}
+
+		traceSpan := span.(*Span).span
+		if traceSpan == nil {
+			t.Fatal("expected a trace span")
+		} else if !traceSpan.IsRecording() {
+			t.Skipf("trce span is not recording")
+		}
+
+		if !traceSpan.SpanContext().HasTraceID() {
+			t.Fatal("span does not have a traceID")
+		} else if !traceSpan.SpanContext().HasSpanID() {
+			t.Fatal("span does not have a spanID")
+		}
+
+		otelSpan := traceSpan.(sdktrace.ReadWriteSpan)
+		if otelSpan.Name() != "test" {
+			t.Fatal("span name is not equal to test")
+		} else if otelSpan.SpanKind() != trace.SpanKindInternal {
+			t.Fatalf("span kind is not internal, instead %v", otelSpan.SpanKind())
+		}
+	})
+
+	t.Run("WithTraceID", func(t *testing.T) {
+		givenTraceID := "5b8aa5a2d2c872e8321cf37308d69df2"
+		ctx, span := tracer.StartSpan(context.TODO(), "test",
+			tengcoruxTracer.WithTraceID(givenTraceID))
+		if ctx == nil {
+			t.Fatal("expected non-nil context")
+		} else if span == nil {
+			t.Fatal("expected non-nil span")
+		}
+
+		otelSpan := span.(*Span).span.(sdktrace.ReadWriteSpan)
+		if otelSpanTraceID := otelSpan.SpanContext().
+			TraceID().
+			String(); otelSpanTraceID != givenTraceID {
+			t.Fatalf("expected traceID to be %s but got %s",
+				givenTraceID, otelSpanTraceID)
+		}
+	})
+
+	t.Run("WithInvalidTraceID", func(t *testing.T) {
+		invalidTraceID := "invalid-trace-id"
+		_, span := tracer.StartSpan(context.TODO(), "test",
+			tengcoruxTracer.WithTraceID(invalidTraceID))
+		if span == nil {
+			t.Fatal("expected non-nil span even with invalid trace ID")
+		}
+		// Verify that an invalid trace ID results in a new valid trace ID being generated
+		otelSpan := span.(*Span).span.(sdktrace.ReadWriteSpan)
+		if !otelSpan.SpanContext().TraceID().IsValid() {
+			t.Fatal("expected a valid trace ID to be generated for invalid input")
+		}
+	})
 }
 
 func TestTracer_Shutdown(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated version number to `"v0.1.1"`.
	- Enhanced context management in the `StartSpan` method with a new helper function for better trace context handling.
  
- **Bug Fixes**
	- Improved readability of method parameters in the `StartSpan` method.

- **Tests**
	- Expanded testing coverage for span creation and validation in the `TestTracer_StartSpan` function with new sub-tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->